### PR TITLE
chore: configure vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "vitest": {
     "globals": true,
-    "environment": "jsdom"
+    "environment": "jsdom",
+    "setupFiles": "./vitest.setup.js"
   }
 }

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,6 @@
+import { afterEach, expect } from 'vitest'
+import matchers from '@testing-library/jest-dom/matchers'
+import { cleanup } from '@testing-library/react'
+
+expect.extend(matchers)
+afterEach(cleanup)


### PR DESCRIPTION
## Summary
- add Vitest setup file to extend Testing Library matchers and cleanup
- reference setup file in Vitest config so the environment loads it

## Testing
- `npm run test:run`
- `npm install --no-save @testing-library/react @testing-library/jest-dom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a083337824832a90dd62c2c700d8ec