### PR TITLE
chore: run lint-staged before tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+npm run precommit
 npm test


### PR DESCRIPTION
## Summary
- run `lint-staged` before tests in pre-commit
- ensure husky pre-commit uses `sh` with `set -e`

## Testing
- `npm run precommit`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a089d01920832a86d70e8375f039a3