### PR TITLE
Add JSON schema and config validation

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["meta", "thresholds", "contacts", "disclaimer", "logicPaths", "medicareNote", "faq"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["appTitle"],
+      "properties": {
+        "appTitle": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "thresholds": {
+      "type": "object",
+      "required": ["lowIncome", "gapIncome"],
+      "properties": {
+        "lowIncome": { "$ref": "#/definitions/threshold" },
+        "gapIncome": { "$ref": "#/definitions/threshold" }
+      },
+      "additionalProperties": false
+    },
+    "contacts": {
+      "type": "object",
+      "required": ["map", "ssa", "va"],
+      "properties": {
+        "map": { "type": "string" },
+        "ssa": { "type": "string" },
+        "va": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "disclaimer": { "type": "string" },
+    "logicPaths": {
+      "type": "object",
+      "required": ["ltci", "va", "low-income", "gap", "nursing-home", "higher-income", "general"],
+      "properties": {
+        "ltci": { "$ref": "#/definitions/logicPath" },
+        "va": { "$ref": "#/definitions/logicPath" },
+        "low-income": { "$ref": "#/definitions/logicPath" },
+        "gap": { "$ref": "#/definitions/logicPath" },
+        "nursing-home": { "$ref": "#/definitions/logicPath" },
+        "higher-income": { "$ref": "#/definitions/logicPath" },
+        "general": { "$ref": "#/definitions/logicPath" }
+      },
+      "additionalProperties": false
+    },
+    "medicareNote": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "faq": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["q", "a"],
+        "properties": {
+          "q": { "type": "string" },
+          "a": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "definitions": {
+    "threshold": {
+      "type": "object",
+      "required": ["monthlyIncome", "assets"],
+      "properties": {
+        "monthlyIncome": { "type": "number" },
+        "assets": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "logicPath": {
+      "type": "object",
+      "required": ["title", "summary", "showMedicareNote"],
+      "properties": {
+        "title": { "type": "string" },
+        "summary": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "showMedicareNote": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/config.validate.js
+++ b/src/config.validate.js
@@ -1,10 +1,9 @@
 import Ajv from "ajv";
 import schema from "../config.schema.json";
-import cfg from "../config.json";
+import cfg from "./config.json";
 const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(schema);
 if (!validate(cfg)) {
-  // eslint-disable-next-line no-console
   console.error("config.json invalid:", validate.errors);
   throw new Error("Invalid config.json");
 }

--- a/src/utils/logic.js
+++ b/src/utils/logic.js
@@ -1,5 +1,6 @@
 // results logic
-import config from "../config.json"
+import "../config.validate.js";
+import config from "../config.json";
 
 /**
  * Determine result key from answers.


### PR DESCRIPTION
## Summary
- add `config.schema.json` to describe configuration structure
- rename and update config validator, integrating it into logic module

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a089949584832ab41a21dc69ac538a