### PR TITLE
test: cover general logic path

### DIFF
--- a/src/utils/__tests__/logic.test.js
+++ b/src/utils/__tests__/logic.test.js
@@ -37,12 +37,10 @@ describe('computeResult', () => {
     expect(res.title).toBe(config.logicPaths['higher-income'].title)
   })
 
-  it('Fallback path (should rarely happen)', () => {
-    // Construct something that avoids all earlier rules
-    const res = computeResult({ a1: 'A', a2: 'C', a3: 'B', a4: 'A' })
-    // NOTE: This actually maps to "gap" per rules; to hit "general" we’d need an invalid combo.
-    // So instead assert that a valid "gap" mapping occurs:
-    expect(res.title).toBe(config.logicPaths['gap'].title)
+  it('General path when answers do not match any rule', () => {
+    // Provide an invalid combination that skips all other logic branches
+    const res = computeResult({ a1: 'Z', a2: 'Z', a3: 'Z', a4: 'Z' })
+    expect(res.title).toBe(config.logicPaths['general'].title)
   })
 })
 


### PR DESCRIPTION
## Summary
- add test that uses an invalid answer combo to trigger the general path in `computeResult`

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68a089b9d398832aadb6d7d96d1edf58