### PR TITLE
Add Ajv dependency for config validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@uswds/uswds": "^3.13.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.8.0"
+        "react-router-dom": "^7.8.0",
+        "ajv": "^6.12.6"
       },
       "devDependencies": {
         "@axe-core/react": "^4.10.2",
@@ -58,7 +59,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -1614,7 +1615,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@uswds/uswds": "^3.13.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.8.0"
+    "react-router-dom": "^7.8.0",
+    "ajv": "^6.12.6"
   },
   "devDependencies": {
     "@axe-core/react": "^4.10.2",


### PR DESCRIPTION
## Summary
- add Ajv to project dependencies so config validator can import it

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68a0acd59788832aa3656a5ce4d705be