### PR TITLE
Use USWDS tokens and hero intro

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Container from "./components/Container.jsx";
 import "./styles/global.css";
 
 /* Pages */
+import Intro from "./pages/Intro.jsx";
 import Questions from "./pages/Questions.jsx";
 import Results from "./pages/Results.jsx";
 import FAQ from "./pages/FAQ.jsx";
@@ -20,10 +21,8 @@ export default function App() {
       <main id="main" role="main" className="main-container">
         <Container>
           <Routes>
-            <Route
-              path="/"
-              element={<Questions />}
-            />
+            <Route path="/" element={<Intro />} />
+            <Route path="/questions" element={<Questions />} />
             <Route
               path="/results"
               element={<Results />}
@@ -38,7 +37,7 @@ export default function App() {
                 <div className="measure-6">
                   <h1 className="margin-top-2">Page not found</h1>
                   <p>Try going back to the screening questions.</p>
-                  <Link className="usa-button" to="/">Start Over</Link>
+                  <Link className="usa-button usa-button--accent-cool" to="/">Start Over</Link>
                 </div>
               }
             />

--- a/src/components/ResultCard.jsx
+++ b/src/components/ResultCard.jsx
@@ -3,7 +3,7 @@
 export default function ResultCard({ title, children, className = "" }) {
   return (
     <section className={`usa-card margin-top-2 ${className}`}>
-      <div className="usa-card__container">
+      <div className="usa-card__container radius-md shadow-md">
         <header className="usa-card__header">
           <h3 className="usa-card__heading">{title}</h3>
         </header>

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -62,7 +62,7 @@ export default function FAQ() {
       </div>
 
       <div className="margin-top-3">
-        <Link className="usa-button usa-button--unstyled" to="/">
+        <Link className="usa-button usa-button--unstyled" to="/questions">
           Back to screening
         </Link>
       </div>

--- a/src/pages/Intro.jsx
+++ b/src/pages/Intro.jsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+import { getMeta } from "../utils/logic.js";
+
+export default function Intro() {
+  const { appTitle } = getMeta();
+  return (
+    <section className="usa-hero">
+      <div className="grid-container">
+        <div className="usa-hero__callout">
+          <h1 className="usa-hero__heading">{appTitle}</h1>
+          <p className="usa-intro">Find services and supports that fit your needs.</p>
+          <Link className="usa-button usa-button--accent-cool" to="/questions">
+            Start screening
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Questions.jsx
+++ b/src/pages/Questions.jsx
@@ -220,7 +220,7 @@ export default function Questions() {
       </fieldset>
 
       <div className="margin-top-4">
-        <button className="usa-button" type="submit">See my results</button>
+        <button className="usa-button usa-button--accent-cool" type="submit">See my results</button>
       </div>
     </form>
   );

--- a/src/pages/Results.jsx
+++ b/src/pages/Results.jsx
@@ -133,7 +133,7 @@ export default function Results() {
 
       {/* Results action buttons */}
       <div className="margin-top-3 no-print results-actions">
-        <button className="usa-button" onClick={() => window.print()} aria-label="Print your results">
+        <button className="usa-button usa-button--accent-cool" onClick={() => window.print()} aria-label="Print your results">
           Print results
         </button>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,9 +2,11 @@
    Global app styles — MD Digital Service + USWDS friendly
    ================================ */
 
+/* Base typography and design tokens */
 :root {
   font-size: 16px;
-  line-height: 1.5;
+  line-height: var(--usa-line-height-body, 1.5);
+  --mda-accent-color: var(--usa-color-accent-cool);
 }
 
 html, body, #root {
@@ -12,10 +14,14 @@ html, body, #root {
 }
 
 body {
-  font-family: "Source Sans Pro", "Source Sans 3", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
-  color: #1b1b1b; /* USWDS ink */
-  background: #ffffff;
+  font-family: var(--usa-font-sans), system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  color: var(--usa-color-ink);
+  background: var(--usa-color-base-lightest);
   margin: 0;
+}
+
+h1, h2, h3 {
+  color: var(--mda-accent-color);
 }
 
 .app-container {
@@ -29,25 +35,11 @@ body {
 .mda-container {
   max-width: 72rem; /* ~1152px */
   margin-inline: auto;
-  padding-inline: 1rem;
+  padding-inline: var(--usa-spacing-3);
 }
 
 a { text-underline-offset: 0.15em; }
 
-/* Minimal fallback button (prefer USWDS .usa-button) */
-.button {
-  display: inline-block;
-  border: 0;
-  padding: .625rem 1rem;
-  border-radius: .25rem;
-  background: #005ea2; /* USWDS primary-700 */
-  color: #fff;
-  cursor: pointer;
-}
-.button:focus {
-  outline: 3px solid #2491ff;
-  outline-offset: 2px;
-}
 
 /* Keep "(Required)" inline when used inside legends */
 .usa-legend .hint-inline {
@@ -55,12 +47,12 @@ a { text-underline-offset: 0.15em; }
   margin-left: 0.25rem;
   font-weight: normal;
   font-size: 0.95em;
-  color: #565c65; /* USWDS gray-60 */
+  color: var(--usa-color-gray-60);
 }
 
 /* Fallback focus ring for interactive controls (USWDS already handles most) */
 :where(a, button, input, select, textarea, [role="button"]):focus-visible {
-  outline: 3px solid #2491ff;
+  outline: 3px solid var(--usa-color-focus);
   outline-offset: 2px;
 }
 
@@ -70,24 +62,24 @@ a { text-underline-offset: 0.15em; }
 .measure-6 a,
 .usa-card__body a,
 .usa-footer__secondary-section a {
-  color: #205493;           /* blue-70v — AAA */
+  color: var(--usa-color-blue-70v);           /* AAA */
 }
 .measure-6 a:visited,
 .usa-card__body a:visited,
 .usa-footer__secondary-section a:visited {
-  color: #1a4480;           /* blue-80v — AAA */
+  color: var(--usa-color-blue-80v);           /* AAA */
 }
 .measure-6 a:hover,
 .usa-card__body a:hover { text-decoration: underline; }
 
 /* Hint/help text a bit darker for AA/AAA */
-.usa-hint { color: #4d4d4d; }
+.usa-hint { color: var(--usa-color-gray-50); }
 
 /* Step indicator labels: ensure strong contrast */
-.usa-step-indicator__segment-label { color: #1b1b1b; }
+.usa-step-indicator__segment-label { color: var(--usa-color-ink); }
 
 /* Footer small text: ensure strong contrast */
-.font-sans-2xs { color: #1b1b1b; }
+.font-sans-2xs { color: var(--usa-color-ink); }
 
 /* ================================
    Print utilities
@@ -106,9 +98,9 @@ a { text-underline-offset: 0.15em; }
   /* Page + base typography */
   @page { margin: 0.75in; }                  /* comfortable margins */
   html, body {
-    font-family: "Source Sans Pro", "Source Sans 3", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif !important;
+    font-family: var(--usa-font-sans), system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif !important;
     font-size: 16px !important;              /* keep on-screen size */
-    color: #1b1b1b !important;
+    color: var(--usa-color-ink) !important;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -122,8 +114,8 @@ a { text-underline-offset: 0.15em; }
   /* “Printed on …” and other print-only hints */
   .only-print {
     display: block !important;
-    margin-top: 0.5rem;
-    color: #565c65;
+    margin-top: var(--usa-spacing-2);
+    color: var(--usa-color-gray-60);
     font-size: 0.95rem;
   }
 
@@ -134,11 +126,11 @@ a { text-underline-offset: 0.15em; }
 
   /* Cards: consistent look & spacing */
   .usa-card {
-    border: 1px solid #ddd !important;
+    border: 1px solid var(--usa-color-gray-20) !important;
     border-radius: .5rem !important;         /* match the rounded look */
     box-shadow: none !important;
     page-break-inside: avoid; break-inside: avoid;
-    margin: 1.25rem 0 !important;            /* space between cards */
+    margin: var(--usa-spacing-4) 0 !important;            /* space between cards */
   }
   .usa-card__container { border: 0 !important; }
   .usa-card__header { display: none !important; } /* hide native header in print */
@@ -147,17 +139,17 @@ a { text-underline-offset: 0.15em; }
   .usa-card .usa-card__body::before {
     content: attr(data-title);
     display: block !important;
-    color: #1b1b1b !important;
+    color: var(--usa-color-ink) !important;
     font-weight: 800 !important;
     font-size: 1.375rem !important;          /* larger, like on-screen */
     line-height: 1.25 !important;
     margin: 0 0 .4rem 0 !important;
-    border-bottom: 1px solid #eee !important;
+    border-bottom: 1px solid var(--usa-color-gray-10) !important;
     padding-bottom: .25rem !important;
   }
 
   /* Comfortable body padding inside cards */
-  .usa-card__body { padding: 1rem 1.25rem !important; }
+  .usa-card__body { padding: var(--usa-spacing-3) var(--usa-spacing-4) !important; }
 
   /* Lists & paragraphs spacing (closer to screen) */
   .usa-card__body p { margin: 0.5rem 0 0 0 !important; }
@@ -183,7 +175,7 @@ a { text-underline-offset: 0.15em; }
     content: "•";
     font-weight: 700;                   /* bold bullet, like screen */
     font-size: 1.05rem;                 /* tweak to taste */
-    margin-right: .35rem;
+    margin-right: var(--usa-spacing-1);
   }
   
   /* FAQ prints expanded and tidy */
@@ -195,7 +187,7 @@ a { text-underline-offset: 0.15em; }
     box-shadow: none !important;
     padding: 0 !important;
     text-align: left !important;
-    color: #1b1b1b !important;
+    color: var(--usa-color-ink) !important;
     font-weight: 800 !important;
     font-size: 1.375rem !important;
     line-height: 1.25 !important;


### PR DESCRIPTION
## Summary
- replace custom button CSS with USWDS design tokens and accent styling
- add intro page with USWDS hero and accent button
- round and shadow cards for subtle depth

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef47c644832a8347a3afae01814e